### PR TITLE
Add sc_main in test

### DIFF
--- a/tests/test_main.cpp
+++ b/tests/test_main.cpp
@@ -13,3 +13,8 @@ int main(int argc, char **argv) {
     ::testing::InitGoogleTest(&argc, argv);
     return RUN_ALL_TESTS();
 }
+
+extern "C" int sc_main(int argc, char** argv) {
+    EXPECT_TRUE(false) << "sc_main called";
+    return EXIT_FAILURE;
+}


### PR DESCRIPTION
Add `sc_main` method in the test to be able to use the shared systemc lib. If the shared library is used and no `sc_main` method is implemented, the linker throws an error.