### PR TITLE
Fix clang compiler warnings

### DIFF
--- a/include/avp64/arm64_cpu.h
+++ b/include/avp64/arm64_cpu.h
@@ -78,6 +78,9 @@ protected:
                                    vcml::vcml_access acs) override;
 
 public:
+    using vcml::component::transport; // needed to not hide vcml transport
+                                      // function by ocx transport
+
     vcml::gpio_initiator_socket_array<> timer_irq_out;
     std::vector<std::shared_ptr<sc_core::sc_event>> timer_events;
 

--- a/include/avp64/system.h
+++ b/include/avp64/system.h
@@ -62,7 +62,7 @@ public:
     system(const system&) = delete;
     virtual ~system() = default;
 
-    int run();
+    int run() override;
 
     virtual void end_of_elaboration() override;
 


### PR DESCRIPTION
Resolves compiler warnings that occur with clang 13.0.1.