### PR TITLE
Fix WFI behavior

### DIFF
--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -47,7 +47,9 @@ jobs:
         working-directory: ${{github.workspace}}/deps/ocx-qemu-arm
 
       - name: Patch unicorn
-        run: git apply ${{github.workspace}}/patches/unicorn-fix-breakpoint.patch
+        run: |
+          git apply ${{github.workspace}}/patches/unicorn-fix-breakpoint.patch
+          git apply ${{github.workspace}}/patches/unicorn-fix-wfi-hint.patch
         working-directory: ${{github.workspace}}/deps/ocx-qemu-arm/unicorn
 
       - name: Configure

--- a/README.md
+++ b/README.md
@@ -40,12 +40,15 @@ For that please follow the installation guideline of `vcml` which can be found [
     - [unicorn-fix-breakpoint.patch](./patches/unicorn-fix-breakpoint.patch): This patch fixes the breakpoint behavior of the VP.
     Without this patch, the VP executes the instruction on a breakpoint hit and stops after the execution.
     The patch stops the VP before the instruction is executed.
+    - [unicorn-fix-wfi-hint.patch](./patches/unicorn-fix-wfi-hint.patch): This patch fixes the *Wait for Interrupt* (WFI) hint of unicorn.
+    Without this patch, WFI instructions are not forwarded to avp64 which decreases the simulation performance.
 
     To apply the patches, execute:
 
     ```bash
     (cd <source-dir>/deps/ocx-qemu-arm && git apply <source-dir>/patches/ocx-qemu-arm-disable-tests.patch)
     (cd <source-dir>/deps/ocx-qemu-arm/unicorn && git apply <source-dir>/patches/unicorn-fix-breakpoint.patch)
+    (cd <source-dir>/deps/ocx-qemu-arm/unicorn && git apply <source-dir>/patches/unicorn-fix-wfi-hint.patch)
 
     ```
 

--- a/README.md
+++ b/README.md
@@ -36,10 +36,10 @@ For that please follow the installation guideline of `vcml` which can be found [
 
 3. Patch submodules: Two patches can be applied to patch the `ocx-qemu-arm` submodule.
 
-    - [ocx-qemu-arm-disable-tests.patch](./patches/ocx-qemu-arm-disable-tests.patch): This patch adds an option to the ocx-qemu-arm projects which allows to disable the tests of the submodule.
+    - [ocx-qemu-arm-disable-tests.patch](./patches/ocx-qemu-arm-disable-tests.patch): This patch adds an option to the ocx-qemu-arm projects which allows disabling the tests of the submodule.
     - [unicorn-fix-breakpoint.patch](./patches/unicorn-fix-breakpoint.patch): This patch fixes the breakpoint behavior of the VP.
     Without this patch, the VP executes the instruction on a breakpoint hit and stops after the execution.
-    The patch stops the VP before the instruction is exectuted.
+    The patch stops the VP before the instruction is executed.
 
     To apply the patches, execute:
 

--- a/patches/unicorn-fix-wfi-hint.patch
+++ b/patches/unicorn-fix-wfi-hint.patch
@@ -1,0 +1,25 @@
+diff --git a/qemu/target/arm/op_helper.c b/qemu/target/arm/op_helper.c
+index e2791dc1..50e81543 100644
+--- a/qemu/target/arm/op_helper.c
++++ b/qemu/target/arm/op_helper.c
+@@ -312,8 +312,18 @@ void HELPER(wfi)(CPUARMState *env, uint32_t insn_len)
+                         target_el);
+     }
+ 
+-    cs->exception_index = EXCP_HLT;
+-    cs->halted = 1;
++    uc_hintfunc_t fn = env->uc->uc_hint_func;
++    void* opaque = env->uc->uc_hint_opaque;
++
++    if (fn != NULL) {
++        env->uc->is_memcb = true; // force adjustment during PC register read
++        fn(opaque, UC_HINT_WFI);
++        env->uc->is_memcb = false;
++    } else {
++        cs->exception_index = EXCP_HLT;
++        cs->halted = 1;
++    }
++
+     cpu_loop_exit(cs);
+ }
+ 


### PR DESCRIPTION
Due to an update of unicorn, WFI calls are not forwarded to avp64. The patch fixes this behavior.