### PR TITLE
Update vcml submodule

### DIFF
--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -39,7 +39,7 @@ jobs:
             -B ${{github.workspace}}/build \
             -DCMAKE_CXX_FLAGS="-Wall -Werror" \
             -DCMAKE_BUILD_TYPE=${{env.BUILD_TYPE}} \
-            -DBUILD_TESTS=ON \
+            -DAVP64_BUILD_TESTS=ON \
             -DOCX_QEMU_ARM_BUILD_TESTS=OFF
 
       - name: Build

--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -37,7 +37,6 @@ jobs:
         run: |
           cmake \
             -B ${{github.workspace}}/build \
-            -DCMAKE_CXX_FLAGS="-Wall -Werror" \
             -DCMAKE_BUILD_TYPE=${{env.BUILD_TYPE}} \
             -DAVP64_BUILD_TESTS=ON \
             -DOCX_QEMU_ARM_BUILD_TESTS=OFF

--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -37,7 +37,7 @@ jobs:
         run: |
           cmake \
             -B ${{github.workspace}}/build \
-            -DCXXFLAGS="-Wall -Werror" \
+            -DCMAKE_CXX_FLAGS="-Wall -Werror" \
             -DCMAKE_BUILD_TYPE=${{env.BUILD_TYPE}} \
             -DBUILD_TESTS=ON \
             -DOCX_QEMU_ARM_BUILD_TESTS=OFF

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -36,7 +36,7 @@ jobs:
           -B ${{github.workspace}}/build \
           -DCMAKE_CXX_FLAGS="-Wall -Werror" \
           -DCMAKE_BUILD_TYPE=${{env.BUILD_TYPE}} \
-          -DBUILD_TESTS=ON \
+          -DAVP64_BUILD_TESTS=ON \
           -DAVP64_LINTER=clang-tidy
 
     - name: Build

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -34,7 +34,6 @@ jobs:
       run: |
         cmake \
           -B ${{github.workspace}}/build \
-          -DCMAKE_CXX_FLAGS="-Wall -Werror" \
           -DCMAKE_BUILD_TYPE=${{env.BUILD_TYPE}} \
           -DAVP64_BUILD_TESTS=ON \
           -DAVP64_LINTER=clang-tidy

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -31,7 +31,13 @@ jobs:
         sudo apt-get install libelf-dev libsdl2-dev libvncserver-dev libslirp-dev ninja-build clang-tidy
 
     - name: Configure
-      run: CXXFLAGS="-Wall -Werror" cmake -B ${{github.workspace}}/build -DCMAKE_BUILD_TYPE=${{env.BUILD_TYPE}} -DBUILD_TESTS=ON -DAVP64_LINTER=clang-tidy
+      run: |
+        cmake \
+          -B ${{github.workspace}}/build \
+          -DCMAKE_CXX_FLAGS="-Wall -Werror" \
+          -DCMAKE_BUILD_TYPE=${{env.BUILD_TYPE}} \
+          -DBUILD_TESTS=ON \
+          -DAVP64_LINTER=clang-tidy
 
     - name: Build
       run: cmake --build ${{github.workspace}}/build --config ${{env.BUILD_TYPE}} -j $(nproc)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -10,7 +10,7 @@
 
 cmake_minimum_required(VERSION 3.6)
 project(avp64)
-option(BUILD_TESTS "Build unit tests" OFF)
+option(AVP64_BUILD_TESTS "Build unit tests" OFF)
 
 include(ExternalProject)
 
@@ -59,8 +59,8 @@ target_link_libraries(avp64 -pthread -lelf)
 install(TARGETS avp64 DESTINATION bin)
 install(DIRECTORY config/ DESTINATION config)
 
-if(BUILD_TESTS)
-    message("Building AVP64 tests")
+if(AVP64_BUILD_TESTS)
+    message(STATUS "Building AVP64 tests")
     enable_testing()
     add_subdirectory(tests)
 endif()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -49,6 +49,7 @@ set(sources
 add_executable(avp64 ${sources})
 
 set_target_properties(avp64 PROPERTIES CXX_CLANG_TIDY "${AVP64_LINTER}")
+target_compile_options(avp64 PRIVATE ${MWR_COMPILER_WARN_FLAGS})
 
 target_include_directories(avp64 PRIVATE ${inc})
 

--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ For that please follow the installation guideline of `vcml` which can be found [
 4. Configure and build the project using `cmake`. During configuration you must
    state whether or not to build the unit tests:
 
-     - `-DBUILD_TESTS=[ON|OFF]`: build unit tests (default: `OFF`)
+     - `-DAVP64_BUILD_TESTS=[ON|OFF]`: build unit tests (default: `OFF`)
 
    Ensure that the environment variable `SYSTEMC_HOME` is correctly set.
    Release and debug build configurations are controlled via the regular
@@ -64,7 +64,7 @@ For that please follow the installation guideline of `vcml` which can be found [
    sudo make install
    ```
 
-   If building with `-DBUILD_TESTS=ON` you can run all unit tests using
+   If building with `-DAVP64_BUILD_TESTS=ON` you can run all unit tests using
    `make test` within `<build-dir>`.
 
 5. After installation, the following new files should be present:


### PR DESCRIPTION
This fixes the missing cmake/common.cmake file which is not included in the old vcml version but needed by the mainline mwr which is cloned by vcml.