### PR TITLE
Run Linux boot in CI

### DIFF
--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -7,20 +7,29 @@ on:
     branches: [ master ]
 
 env:
-  BUILD_TYPE: Release
   TARGET_ARCH: linux64
 
 jobs:
   build:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
+    strategy:
+      fail-fast: false
+      matrix:
+        BUILD_TYPE: [Release, Debug]
 
     name: Build AVP64
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
         with:
           submodules: 'recursive'
+
+      - name: Download software
+        run: |
+          wget https://github.com/aut0/avp64_sw/releases/latest/download/linux.tar.gz
+          tar -xvf linux.tar.gz
+          rm linux.tar.gz
 
       - name: Setup Dependencies
         run: |
@@ -37,15 +46,22 @@ jobs:
         run: |
           cmake \
             -B ${{github.workspace}}/build \
-            -DCMAKE_BUILD_TYPE=${{env.BUILD_TYPE}} \
+            -DCMAKE_BUILD_TYPE=${{matrix.BUILD_TYPE}} \
             -DAVP64_BUILD_TESTS=ON \
             -DOCX_QEMU_ARM_BUILD_TESTS=OFF
 
       - name: Build
-        run: cmake --build ${{github.workspace}}/build --config ${{env.BUILD_TYPE}} -j $(nproc)
+        run: cmake --build ${{github.workspace}}/build --config ${{matrix.BUILD_TYPE}} -j $(nproc)
 
       - name: Test
         env:
           LD_LIBRARY_PATH: ${{github.workspace}}/build/ocx-qemu-arm
         working-directory: ${{github.workspace}}/build
-        run: ctest -C ${{env.BUILD_TYPE}} --output-on-failure
+        run: |
+          ctest -C ${{matrix.BUILD_TYPE}} --output-on-failure --output-junit testreport.xml
+
+      - name: Publish Test Report
+        uses: mikepenz/action-junit-report@v4
+        if: always()
+        with:
+          report_paths: ${{github.workspace}}/build/testreport.xml

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -13,14 +13,14 @@ env:
 jobs:
   lint:
     name: lint
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
 
     strategy:
       fail-fast: false
 
     steps:
     - name: Checkout
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
       with:
         submodules: 'recursive'
 
@@ -28,7 +28,12 @@ jobs:
       run: |
         sudo add-apt-repository -y "deb http://archive.ubuntu.com/ubuntu `lsb_release -sc` main universe restricted multiverse"
         sudo apt-get update -y -qq
-        sudo apt-get install libelf-dev libsdl2-dev libvncserver-dev libslirp-dev ninja-build clang-tidy
+        sudo apt-get install libelf-dev libsdl2-dev libvncserver-dev libslirp-dev clang-tidy
+
+    - name: Patch unicorn
+      run: |
+        git apply ${{github.workspace}}/patches/unicorn-*.patch
+      working-directory: ${{github.workspace}}/deps/ocx-qemu-arm/unicorn
 
     - name: Configure
       run: |
@@ -36,7 +41,9 @@ jobs:
           -B ${{github.workspace}}/build \
           -DCMAKE_BUILD_TYPE=${{env.BUILD_TYPE}} \
           -DAVP64_BUILD_TESTS=ON \
-          -DAVP64_LINTER=clang-tidy
+          -DOCX_QEMU_ARM_BUILD_TESTS=OFF \
+          -DAVP64_LINTER="clang-tidy" \
+          -DCMAKE_CXX_STANDARD=17
 
     - name: Build
       run: cmake --build ${{github.workspace}}/build --config ${{env.BUILD_TYPE}} -j $(nproc)

--- a/.github/workflows/style.yml
+++ b/.github/workflows/style.yml
@@ -8,13 +8,12 @@ on:
 
 jobs:
   style:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     steps:
     - name: Checkout
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
       with:
         submodules: 'recursive'
 
     - name: Check code style
       run: deps/vcml/utils/format -n
-

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -53,9 +53,8 @@ target_compile_options(avp64 PRIVATE ${MWR_COMPILER_WARN_FLAGS})
 
 target_include_directories(avp64 PRIVATE ${inc})
 
-target_link_libraries(avp64 vcml)
 target_link_libraries(avp64 ${CMAKE_DL_LIBS})
-target_link_libraries(avp64 -pthread -lelf)
+target_link_whole_archives(avp64 vcml)
 
 install(TARGETS avp64 DESTINATION bin)
 install(DIRECTORY config/ DESTINATION config)

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -9,13 +9,16 @@
 ##############################################################################
 
 set(CMAKE_EXE_LINKER_FLAGS -rdynamic)
+find_package(PythonInterp "3.9" REQUIRED)
 
 add_library(test_main test_main.cpp)
 target_link_libraries(test_main gtest)
 
 macro(link_test test)
     target_include_directories(${test} PRIVATE ${inc} ${SYSTEMC_INCLUDE_DIRS})
-    target_link_libraries(${test} test_main gtest vcml ${SYSTEMC_LIBRARIES} ${LIBELF_LIBRARIES} dl)
+    target_link_libraries(${test} test_main gtest vcml ${SYSTEMC_LIBRARIES} ${LIBELF_LIBRARIES} ${CMAKE_DL_LIBS})
+    target_compile_options(${test} PRIVATE ${MWR_COMPILER_WARN_FLAGS})
+    set_target_properties(${test} PROPERTIES CXX_CLANG_TIDY "${AVP64_LINTER}")
     add_test(NAME ${test} COMMAND ${test} ${CMAKE_CURRENT_SOURCE_DIR})
     set_tests_properties(${test} PROPERTIES TIMEOUT 5)
 endmacro()
@@ -23,3 +26,24 @@ endmacro()
 add_executable(arm64_cpu_test arm64_cpu_test.cpp
         ${src}/arm64_cpu.cpp)
 link_test(arm64_cpu_test)
+
+function(linux_boot nrcpu config timeout)
+    set(name "linux-boot-${nrcpu}-cpus")
+    set(config ${CMAKE_SOURCE_DIR}/config/${config})
+    set(script ${CMAKE_CURRENT_BINARY_DIR}/${name}.py)
+    get_target_property(ld_library_path ocx-qemu-arm BINARY_DIR)
+    configure_file(linux_boot.py.in ${script})
+    file(GENERATE OUTPUT ${script} INPUT ${script})
+    add_test(NAME ${name} COMMAND ${PYTHON_EXECUTABLE} ${script})
+    set_tests_properties(${name} PROPERTIES TIMEOUT ${timeout})
+    set_tests_properties(${name} PROPERTIES ENVIRONMENT "${ENVVARS}")
+endfunction()
+
+linux_boot(1 arm64_linux_4_19_4-x1.cfg 600)
+
+string(TOUPPER ${CMAKE_BUILD_TYPE} BUILD_TYPE_UPPER)
+if(BUILD_TYPE_UPPER STREQUAL RELEASE)
+    linux_boot(2 arm64_linux_4_19_4-x2.cfg 600)
+    linux_boot(4 arm64_linux_4_19_4-x4.cfg 600)
+    linux_boot(8 arm64_linux_4_19_4-x8.cfg 600)
+endif()

--- a/tests/linux_boot.py.in
+++ b/tests/linux_boot.py.in
@@ -1,0 +1,59 @@
+#!/usr/bin/env python3
+
+##############################################################################
+#                                                                            #
+# Copyright 2023 Nils Bosbach, Jan Henrik Weinstock                          #
+#                                                                            #
+# This software is licensed under the MIT license.                           #
+# A copy of the license can be found in the LICENSE file at the root         #
+# of the source tree.                                                        #
+#                                                                            #
+##############################################################################
+
+import sys
+import pexpect
+import os
+
+sim='$<TARGET_FILE:avp64>'
+cfg='@config@'
+
+cmdline = f'{sim} -f {cfg}';
+
+print(cmdline)
+
+p = pexpect.spawn(cmdline, logfile=sys.stdout, timeout=None, encoding='utf-8', env=os.environ | {'LD_LIBRARY_PATH': '@ld_library_path@'})
+
+# did all secondary cpus boot?
+for cpu in range(1, @nrcpu@):
+    p.expect(f'CPU{cpu}: Booted secondary processor 0x000000000{cpu}')
+
+# did our drivers initialize?
+p.expect('10009000.uart: ttyAMA0 at MMIO 0x10009000')
+p.expect('1000a000.uart: ttyAMA1 at MMIO 0x1000a000')
+p.expect('1000b000.uart: ttyAMA2 at MMIO 0x1000b000')
+p.expect('1000c000.uart: ttyAMA3 at MMIO 0x1000c000')
+p.expect('timeriomem_rng 10007000.rng: 32bits')
+p.expect('spi_oc_tiny 10147000.spi')
+p.expect('mmc0: SDHCI controller on f_sdh30')
+p.expect('mmc0: new SDHC card at address 0000')
+p.expect('ethoc 1000d000.ethernet eth0: Link is Up')
+
+# did we get a login prompt?
+p.expect('avp64-dom0 login:')
+p.sendline('root')
+
+# can we run commands?
+p.expect('#')
+p.sendline('uname')
+p.expect('Linux')
+
+# did all processors boot up?
+p.expect('#')
+p.sendline('cat /proc/cpuinfo')
+for cpu in range(@nrcpu@):
+    p.expect('processor')
+
+# test ok - shut down simulation
+p.expect('#')
+p.sendline('devmem 0x10008000 32 1')
+p.expect(pexpect.EOF)


### PR DESCRIPTION
Add a test that fetches a Linux kernel build from avp64_sw and runs the boot process. During boot, special prompts of the drivers are expected to pass the test. Debug builds are added. The used Ubuntu version of the action is updated to 22.04 to support Python 3.9.